### PR TITLE
Fix "locust_slave_count" query

### DIFF
--- a/locust_exporter.py
+++ b/locust_exporter.py
@@ -34,10 +34,9 @@ class LocustCollector(object):
         metric.add_sample('locust_errors', value=err['occurences'], labels={'path':err['name'], 'method':err['method']})
     yield metric
 
-    if 'slave_count' in response:
-        metric = Metric('locust_slave_count', 'Locust number of slaves', 'gauge')
-        metric.add_sample('locust_slave_count', value=response['slave_count'], labels={})
-        yield metric
+    metric = Metric('locust_slave_count', 'Locust number of slaves', 'gauge')
+    metric.add_sample('locust_slave_count', value=len(response['slaves']), labels={})
+    yield metric
 
     metric = Metric('locust_fail_ratio', 'Locust failure ratio', 'gauge')
     metric.add_sample('locust_fail_ratio', value=response['fail_ratio'], labels={})


### PR DESCRIPTION
Here is an example of response in json format when querying the locust (version 0.11.0) HTTP endpoint (/stats/requests):

```
....
"slaves": [
    {
      "id": "ip-10-30-41-5_c934ac121c8044829aea4617657920e9", 
      "state": "running", 
      "user_count": 25
    }, 
    {
      "id": "ip-10-30-41-140_de51336098954e1dbb197b3d0249109d", 
      "state": "running", 
      "user_count": 25
    }
  ],
....
````

So, we need to change the way to count the length of "slaves" list correctly.

```
len(response['slaves'])
```

Test passed well.

Please kindly review and merge this PR when you have free time.
Thanks!
